### PR TITLE
Fixed deploy on Heroku url

### DIFF
--- a/guides/heroku.md
+++ b/guides/heroku.md
@@ -8,7 +8,7 @@ Launch code-server on Heroku to get on-demand dev environments that turn off whe
 
 ## Step 1: Click to deploy
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/cdr/deploy-code-server/tree/main)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/cdr/deploy-code-server)
 
 ---
 


### PR DESCRIPTION
https://heroku.com/deploy?template=https://github.com/cdr/deploy-code-server/tree/main sometimes goes to error page, so I changed that for https://dashboard.heroku.com/new?template=https://github.com/cdr/deploy-code-server

